### PR TITLE
Add option to customize the email placeholder, fixes #55

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -152,7 +152,7 @@ export default class Feedback {
 						<p>${ feedbackType.icon } ${ feedbackType.text }</p>
 					</div>
 					<div class="feedback-content">
-							${ this.options.emailField ? '<input id="feedback-email" type="email" name="email" placeholder="Email address (optional)">' : '' }
+							${ this.options.emailField ? '<input id="feedback-email" type="email" name="email">' : '' }
 							<textarea id="feedback-message" name="feedback" autofocus type="text" maxlength="500" rows="5" placeholder="${ this.options.inputPlaceholder }"></textarea>
 							<div id="feedback-actions" class="feedback-actions">
 								<button type="button" id="feedback-back">${ this.options.backText }</button>


### PR DESCRIPTION
The email placeholder is hardcoded so we cannot use it in different languages.

Fixes #55